### PR TITLE
[KOUNT-262] Update Kount360 to support Magento 2.4.9

### DIFF
--- a/Setup/Patch/Data/AddKountOrderStatus.php
+++ b/Setup/Patch/Data/AddKountOrderStatus.php
@@ -28,8 +28,7 @@ class AddKountOrderStatus implements DataPatchInterface
 
     /**
      * @return void
-     * @throws LocalizedException
-     * @throws Zend_Validate_Exception
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function apply(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,18 @@
         }
     ],
     "require": {
-        "magento/module-backend": "^100.0.0|^101.0.0|^102.0.0",
+        "php": "^8.2|^8.3|^8.4",
+        "magento/module-backend": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
         "magento/module-customer": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
         "magento/module-sales": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
-        "magento/module-checkout": "^100.0.0",
-        "magento/module-payment": "^100.0.0",
-        "magento/module-paypal": "^100.0.0|^101.0.0",
-        "magento/module-config": "^100.0.0|^101.0.0",
-        "magento/module-store": "^100.0.0|^101.0.0",
-        "magento/module-directory": "^100.0.0",
+        "magento/module-checkout": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
+        "magento/module-payment": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
+        "magento/module-paypal": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
+        "magento/module-config": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
+        "magento/module-store": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
+        "magento/module-directory": "^100.0.0|^101.0.0|^102.0.0|^103.0.0",
         "magento/framework": "^102.0.0|^103.0.0",
-        "magento/module-sales-rule": "^100.0.0|^101.0.0"
+        "magento/module-sales-rule": "^100.0.0|^101.0.0|^102.0.0|^103.0.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "kount",
         "kount 360"
     ],
-    "version": "1.1.14",
+    "version": "1.1.15",
     "type": "magento2-module",
     "license": [
         "proprietary"


### PR DESCRIPTION
### Summary

  The Kount360 extension is updated to declare compatibility with Magento 2.4.9 by expanding Composer dependency version constraints to include the ^103.0.0 package versions that ship with that release. A PHP version constraint
  (^8.2|^8.3|^8.4) is also added to match the PHP support matrix for Magento 2.4.9, and a deprecated Zend_Validate_Exception throw declaration is removed from the data patch class to reflect its removal from the framework.

### What Has Changed

**Composer Configuration (composer.json):**
  - Added explicit php constraint ^8.2|^8.3|^8.4 to align with Magento 2.4.9's supported PHP versions
  - Expanded version range for magento/module-backend to include ^103.0.0
  - Expanded version ranges for magento/module-checkout, magento/module-payment, magento/module-paypal, magento/module-config, magento/module-store, magento/module-directory, and magento/module-sales-rule — all updated to include
  ^101.0.0|^102.0.0|^103.0.0 where previously only older ranges were declared

**Data Patch (Setup/Patch/Data/AddKountOrderStatus.php):**
  - Removed @throws Zend_Validate_Exception from the apply() method docblock — this class no longer exists in Magento 2.4.9 / modern Zend/Laminas
  - Changed @throws LocalizedException to the fully qualified @throws \Magento\Framework\Exception\LocalizedException to remove the implicit use dependency

### Why Was This Change Added

Magento 2.4.9 ships with incremented package versions (the ^103.0.0 series) for its core modules and requires PHP 8.2+. Without these updated constraints, Composer's dependency resolver rejects the Kount360 extension during installation on a 2.4.9 store, blocking merchants from upgrading. The version ranges are additive (existing lower bounds are preserved), so the module remains installable on Magento 2.4.6–2.4.8 as well.

The Zend_Validate_Exception removal reflects the completed Laminas migration in Magento 2.4.x — that class was silently absent in recent versions and its presence in the docblock was misleading. Using the fully qualified exception name makes the dependency explicit without requiring a use import.